### PR TITLE
feat: exponential backoff for seconds

### DIFF
--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -188,15 +188,28 @@ export class Queue {
       priority?: number
       runIn?: Duration
       retryIn?: Duration
+      retryExponential?: boolean
     } = {},
     startQueue = true,
   ) {
-    const { attempts = 0, timeout = 0, priority = 0, runIn, retryIn } = options
+    const {
+      attempts = 0,
+      timeout = 0,
+      priority = 0,
+      runIn,
+      retryIn,
+      retryExponential = false,
+    } = options
     const id: string = Uuid.v4()
     const job: RawJob = {
       id,
       payload: JSON.stringify(payload || {}),
-      metaData: JSON.stringify({ failedAttempts: 0, errors: [], retryIn: retryIn }),
+      metaData: JSON.stringify({
+        failedAttempts: 0,
+        errors: [],
+        retryIn: retryIn,
+        retryExponential,
+      }),
       active: FALSE,
       created: new Date().toISOString(),
       scheduled_for: runIn ? add(new Date(), runIn).toISOString() : "now",
@@ -403,13 +416,27 @@ export class Queue {
     } catch (error) {
       worker.triggerFailure(job, error as Error)
       const { attempts } = rawJob
-      let { errors, failedAttempts, retryIn } = JSON.parse(rawJob.metaData)
+      let { errors, failedAttempts, retryIn, retryExponential } = JSON.parse(rawJob.metaData)
       failedAttempts++
       let failed = ""
       if (failedAttempts >= attempts) {
         failed = new Date().toISOString()
       }
-      const metaData = JSON.stringify({ errors: [...errors, error], failedAttempts, retryIn })
+      const metaData = JSON.stringify({
+        errors: [...errors, error],
+        failedAttempts,
+        retryIn,
+        retryExponential,
+      })
+
+      if (retryExponential && retryIn.seconds) {
+        const baseDelay = parseInt(retryIn.seconds)
+        const exponentialDelay = baseDelay * Math.pow(2, failedAttempts - 1)
+        retryIn = {
+          seconds: exponentialDelay,
+        }
+      }
+
       this.jobStore.updateJob({
         ...rawJob,
         ...{


### PR DESCRIPTION
This pull request introduces a new feature to the `Queue` class in `src/Queue.ts` to support exponential backoff retries. The main changes include adding a new `retryExponential` option and updating the job metadata and retry logic accordingly.

Enhancements to retry logic:

* [`src/Queue.ts`](diffhunk://#diff-d76eaa8d5e94c312de544b3b28759c8c92e6ad8419175058bdbe8a0612eaa087R191-R212): Added a new `retryExponential` option to the `Queue` class, allowing jobs to retry with exponential backoff.
* [`src/Queue.ts`](diffhunk://#diff-d76eaa8d5e94c312de544b3b28759c8c92e6ad8419175058bdbe8a0612eaa087L406-R439): Updated job metadata to include the `retryExponential` option and adjusted the retry logic to calculate exponential delays when this option is enabled.