### PR TITLE
feat: update to payload too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-job-queue",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "An SQLite based job queue for Expo",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/QueueStore.ts
+++ b/src/QueueStore.ts
@@ -150,8 +150,8 @@ export class QueueStore {
 
   async updateJob(job: RawJob) {
     await this.query(
-      "UPDATE job SET active = ?, failed = ?, meta_data = ?, attempts = ?, scheduled_for = ? WHERE id = ?;",
-      [job.active, job.failed, job.metaData, job.attempts, job.scheduled_for, job.id],
+      "UPDATE job SET active = ?, failed = ?, meta_data = ?, attempts = ?, scheduled_for = ?, payload = ? WHERE id = ?;",
+      [job.active, job.failed, job.metaData, job.attempts, job.scheduled_for, job.payload, job.id],
     )
   }
 


### PR DESCRIPTION
This pull request updates the `expo-job-queue` package to version 1.4.5 and introduces a change to the `QueueStore` class to support updating the `payload` field in the job database. Below are the key changes:

### Version update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.4.4` to `1.4.5` to reflect the new changes.

### Database update enhancement:
* [`src/QueueStore.ts`](diffhunk://#diff-a33271f1ee5d092d5cf823c6a57cac5652ac2da2cdb7f43abd095aac788a7f43L153-R154): Modified the `updateJob` method to include the `payload` field in the SQL `UPDATE` statement and its corresponding parameter binding, allowing the `payload` to be updated in the job database.